### PR TITLE
Close HTTP connections

### DIFF
--- a/collector/writer.go
+++ b/collector/writer.go
@@ -37,7 +37,7 @@ func (writer InfluxdbWriter) writeInts(s Stats) error {
 	c, err := client.NewHTTPClient(writer.config)
 	if err != nil {
 		log.Print(err)
-    c.Close()
+		c.Close()
 		return err
 	}
 
@@ -48,7 +48,7 @@ func (writer InfluxdbWriter) writeInts(s Stats) error {
 	})
 	if err != nil {
 		log.Print(err)
-    c.Close()
+		c.Close()
 		return err
 	}
 
@@ -107,10 +107,10 @@ func (writer InfluxdbWriter) writeInts(s Stats) error {
 				fmt.Println(response.Results)
 			}
 		}
-    c.Close()
+		c.Close()
 		return err
 	}
-  c.Close()
+	c.Close()
 	return nil
 }
 

--- a/collector/writer.go
+++ b/collector/writer.go
@@ -37,6 +37,7 @@ func (writer InfluxdbWriter) writeInts(s Stats) error {
 	c, err := client.NewHTTPClient(writer.config)
 	if err != nil {
 		log.Print(err)
+    c.Close()
 		return err
 	}
 
@@ -47,6 +48,7 @@ func (writer InfluxdbWriter) writeInts(s Stats) error {
 	})
 	if err != nil {
 		log.Print(err)
+    c.Close()
 		return err
 	}
 
@@ -105,9 +107,10 @@ func (writer InfluxdbWriter) writeInts(s Stats) error {
 				fmt.Println(response.Results)
 			}
 		}
+    c.Close()
 		return err
 	}
-
+  c.Close()
 	return nil
 }
 


### PR DESCRIPTION
This pull request closes the HTTP connection after sending the data.
We ran into port exhaustion issues, and these were fixed by this change.